### PR TITLE
Fix how token is pulled from request header

### DIFF
--- a/src/jwt_authenticator/authentication_handler.py
+++ b/src/jwt_authenticator/authentication_handler.py
@@ -117,7 +117,7 @@ class AuthenticationHandler:
             @wraps(func)
             def func_wrapper(*args, **kwargs):
                 try:
-                    token = request.headers.get("Authorization", None)
+                    token = request.headers.get("Authorization", None).split(" ")[1]
                     if not token:
                         abort(401, description="No token")
 

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,4 +1,4 @@
 SECRET = "foobar"
 AUDIENCE = "fred"
 JWKS_URL = "http://bar.foo"
-GROUPS_CLAIM = "group"
+GROUPS_CLAIM = "groups"

--- a/tests/test_jwt_authenticator.py
+++ b/tests/test_jwt_authenticator.py
@@ -37,7 +37,7 @@ class JwtAuthenticatorTests(unittest.TestCase):
         ctx.push()
 
         audience = 'http://www.service.wingdings.com/'
-        roles = {'group': ['admin', 'user'], 'aud': audience}
+        roles = {'groups': ['admin', 'user'], 'aud': audience}
         secret = secrets.token_urlsafe(32)
 
         token = AuthenticationHandler.generate_auth_token(roles, secret)
@@ -46,8 +46,8 @@ class JwtAuthenticatorTests(unittest.TestCase):
             audience=audience,
             algorithms=["HS256"]
         )
-        self.assertTrue(decoded_token['group'][0] == 'admin')
-        self.assertTrue(decoded_token['group'][1] == 'user')
+        self.assertTrue(decoded_token['groups'][0] == 'admin')
+        self.assertTrue(decoded_token['groups'][1] == 'user')
 
     def test_generate_and_validate_token_512_success(self):
         """ Generate and decode a token using a different algorithm"""
@@ -59,7 +59,7 @@ class JwtAuthenticatorTests(unittest.TestCase):
         ctx.push()
 
         audience = 'http://www.service.wingdings.com/'
-        roles = {'group': ['admin', 'user'], 'aud': audience}
+        roles = {'groups': ['admin', 'user'], 'aud': audience}
         secret = secrets.token_urlsafe(32)
 
         token = AuthenticationHandler.generate_auth_token(roles, secret,
@@ -68,14 +68,14 @@ class JwtAuthenticatorTests(unittest.TestCase):
             token=token, key=secret,
             audience=audience, algorithms=["HS512"]
         )
-        self.assertTrue(decoded_token['group'][0] == 'admin')
-        self.assertTrue(decoded_token['group'][1] == 'user')
+        self.assertTrue(decoded_token['groups'][0] == 'admin')
+        self.assertTrue(decoded_token['groups'][1] == 'user')
 
     def test_validate_token_expired(self):
         """ Expired tokens should throw exceptions"""
 
         audience = 'http://www.service.wingdings.com/'
-        roles = {'group': ['admin', 'user'], 'aud': audience,
+        roles = {'groups': ['admin', 'user'], 'aud': audience,
                  'exp': datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=15)}
         secret = secrets.token_urlsafe(32)
 
@@ -90,7 +90,7 @@ class JwtAuthenticatorTests(unittest.TestCase):
         """ A role is specified and not matched"""
 
         audience = 'http://www.service.wingdings.com/'
-        roles = {'group': ['admin', 'user'], 'aud': audience}
+        roles = {'groups': ['admin', 'user'], 'aud': audience}
         secret = secrets.token_urlsafe(32)
 
         token = AuthenticationHandler.generate_auth_token(roles, secret)
@@ -109,15 +109,15 @@ class JwtAuthenticatorTests(unittest.TestCase):
         ctx.push()
 
         audience = 'http://www.service.wingdings.com/'
-        roles = {'group': ['admin', 'user'], 'aud': audience}
+        roles = {'groups': ['admin', 'user'], 'aud': audience}
         secret = secrets.token_urlsafe(32)
 
         token = AuthenticationHandler.generate_auth_token(roles, secret)
         decoded_token = AuthenticationHandler.validate_and_decode_token(
             token=token, key=secret, role_name="admin",
             audience=audience)
-        self.assertTrue(decoded_token['group'][0] == 'admin')
-        self.assertTrue(decoded_token['group'][1] == 'user')
+        self.assertTrue(decoded_token['groups'][0] == 'admin')
+        self.assertTrue(decoded_token['groups'][1] == 'user')
 
     def test_invalid_token_secret_mismatch(self):
         """ Make sure invalid tokens are rejected"""
@@ -181,7 +181,7 @@ class JwtAuthenticatorTests(unittest.TestCase):
 
         jwks_url = f"file://{key_path}"
         audience = 'http://www.service.wingdings.com/'
-        roles = {'group': ['admin', 'user'], 'aud': audience}
+        roles = {'groups': ['admin', 'user'], 'aud': audience}
         token = AuthenticationHandler.generate_auth_token(roles, private_key, "RS256",
                                                           headers={"kid": "kid1"})
 

--- a/tests/test_jwt_authenticator.py
+++ b/tests/test_jwt_authenticator.py
@@ -3,6 +3,7 @@ import json
 import os
 import secrets
 import unittest
+from datetime import timezone
 
 from flask import Flask
 from jwt.utils import base64url_encode
@@ -76,7 +77,7 @@ class JwtAuthenticatorTests(unittest.TestCase):
 
         audience = 'http://www.service.wingdings.com/'
         roles = {'groups': ['admin', 'user'], 'aud': audience,
-                 'exp': datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=15)}
+                 'exp': datetime.datetime.now(timezone.utc) - datetime.timedelta(minutes=15)}
         secret = secrets.token_urlsafe(32)
 
         token = AuthenticationHandler.generate_auth_token(roles, secret)


### PR DESCRIPTION
When the decorator is used, it tries to pull Auth information from the request header. The header contains auth type and token. It tries to parse the entire string as a token. This throws "Invalid Padding" exception. Also the "GROUPS_CLAIM" in the token generated by azure AD s called "groups". Changing tests to reflect the same. 